### PR TITLE
Some configurations added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,112 @@
+### Code-Java ###
+
+.project
+factoryConfiguration.json
+
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Apache-Ant
+build/*
+!build/build.xml
+dist/*
+
+# Eclipse
+.project
+.metadata
+.classpath
+bin/**
+tmp/**
+tmp/**/*
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.loadpath
+.settings/
+# External tool builders
+.externalToolBuilders/
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+/bin/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# ili2c - The INTERLIS Compiler
+Checks the syntactical correctness of an [INTERLIS](https://www.interlis.ch/content/index.php?language=e "Interlis - The tool to describe, integrate and coordinate geodata.") data model.
+
+## License
+ili2c is licensed under the [LGPL](https://www.gnu.org/licenses/lgpl.txt) (Lesser GNU Public License).
+
+## System Configuration
+For the current version of ili2c, you will need a JAVA software development kit (JDK) version 1.6 or a more recent version
+must be installed on your system. A free version of the JAVA software development kit (JDK) is available [here](http://www.oracle.com/technetwork/java/javase/downloads/index.html) .
+Also required is the build tool ant. [Download](http://ant.apache.org) and install it as documented there.
+
+## Installation
+In order to install the INTERLIS Compiler, extract the ZIP file into a new directory.
+
+## How to compile it?
+To compile the INTERLIS Compiler, change to the newly created directory and enter the following command at the commandline prompt:
+
+- Unix
+~~~
+export CLASSPATH="lib/antlr.jar:$CLASSPATH"
+ant jar
+~~~
+- Windows
+~~~
+set CLASSPATH=lib\antlr.jar;%CLASSPATH%;.;
+ant jar
+~~~
+To build a binary distribution, use
+~~~
+ant bindist
+~~~

--- a/build.xml
+++ b/build.xml
@@ -157,7 +157,7 @@
   <target depends="init,genparser24,genparser1,genparser22,genparser23,genmetavalue,genmodelscan,ili1undef" name="compile">
     <!-- Compile the java code from ${src} into ${build}/classes -->
     <mkdir dir="${build}/classes"/>
-    <javac destdir="${build}/classes" includes="**/*.java" debug="on"  source="1.6" target="1.6">
+    <javac destdir="${build}/classes" includes="**/*.java" debug="on"  source="1.6" target="1.6" encoding="UTF-8" includeantruntime="false">
       <classpath>
         <!-- <pathelement location="src-hd53/classes"/> -->
         <pathelement location="lib/antlr.jar"/>


### PR DESCRIPTION
This is the only modification I made to the project to add it to umleditor with utf-8 enconding.
- Information about the configuration of antlr is added to compile the project in windows and unix.
- Fix warning 'includeantruntime' was not set.
