### PR TITLE
Verify coords match or extend a concrete definition when overriding a generic context

### DIFF
--- a/ili2c-core/src/main/java/ch/interlis/ili2c/metamodel/ContextDef.java
+++ b/ili2c-core/src/main/java/ch/interlis/ili2c/metamodel/ContextDef.java
@@ -37,5 +37,24 @@ public class ContextDef extends AbstractLeafElement{
         for (Domain concrete : concretes) {
             concrete.getType().checkTypeExtension(genericType);
         }
+
+        Model model = (Model) getContainer(Model.class);
+        Domain[] concretesAllowedInImportedModel = model.resolveGenericDomainFromImportedModels(generic);
+        if (concretesAllowedInImportedModel != null) {
+            for (Domain concrete : concretes) {
+                if (!matchesOrExtendsAllowedDomain(concrete, concretesAllowedInImportedModel)) {
+                    throw new IllegalStateException(formatMessage("err_contextdef_domain_not_extending", concrete.getName(), generic.getName()));
+                }
+            }
+        }
+    }
+
+    private boolean matchesOrExtendsAllowedDomain(Domain concrete, Domain[] allowedInImportedModel) {
+        for (Domain allowed : allowedInImportedModel) {
+            if (concrete == allowed || concrete.isExtendingIndirectly(allowed)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/ili2c-core/src/main/java/ch/interlis/ili2c/metamodel/Model.java
+++ b/ili2c-core/src/main/java/ch/interlis/ili2c/metamodel/Model.java
@@ -594,6 +594,12 @@ public void setXmlns(String xmlns) {
 	      Set<Model> visitedModels=new HashSet<Model>();
 	      return resolveGenericDomain_deepFirstSearch(generic,this,visitedModels);
 	  }
+
+    public Domain[] resolveGenericDomainFromImportedModels(Domain generic) {
+        Set<Model> visitedModels = new HashSet<Model>();
+        return resolveGenericDomain_deepFirstSearch(generic, this, visitedModels);
+    }
+
     private static Domain[] resolveGenericDomain_deepFirstSearch(Domain generic,Model model,Set<Model> visitedModels) {
         Model imps[]=model.getImporting();
         for(int i=imps.length-1;i>=0;i--) {

--- a/ili2c-core/src/main/resources/ch/interlis/ili2c/metamodel/ErrorMessages.properties
+++ b/ili2c-core/src/main/resources/ch/interlis/ili2c/metamodel/ErrorMessages.properties
@@ -520,6 +520,7 @@ err_constraint_viewref=CONSTRAINTS OF requires a reference to a viewable in the 
 err_existConstraint_RequiredInTypeMismatch=The attribute type of "{0}" does not match "{1}".
 err_contextdef_nonunique=There can not be a ContextDef "{0}" in {1} because there is already a model element with the same name. Use a different name.
 err_contextdef_domain_not_generic=The domain {0} of context {1} must be generic.
+err_contextdef_domain_not_extending=The domain {0} must match or extend a domain of the existing context for generic type {1}.
 err_expr_noLogical=logical expression required.
 err_expr_noNumeric=numeric expression required.
 err_expr_incompatibleTypes=incompatible datatypes

--- a/ili2c-core/src/main/resources/ch/interlis/ili2c/metamodel/ErrorMessages_es.properties
+++ b/ili2c-core/src/main/resources/ch/interlis/ili2c/metamodel/ErrorMessages_es.properties
@@ -520,6 +520,7 @@ err_constraint_viewref=CONSTRAINTS OF requiere una referencia a una vista en el 
 err_existConstraint_RequiredInTypeMismatch=El tipo de atributo de "{0}" no coincide con el de "{1}".
 err_contextdefs_nonunique=No puede haber un ContextDef "{0}" en {1} porque ya hay un elemento del modelo con el mismo nombre. Utilice un nombre diferente.		
 err_contextdef_domain_not_generic=El dominio {0} del contexto {1} debe ser genérico.
+err_contextdef_domain_not_extending=El dominio {0} debe coincidir o extender un dominio del contexto existente para el tipo genérico {1}.
 err_expr_noLogical=se requiere una expresión lógica.
 err_expr_noNumeric=Se requiere una expresión numérica.
 err_expr_incompatibleTypes=tipos de datos incompatibles

--- a/test/data/ili24/genericValueRanges/multipleContextsExtending.ili
+++ b/test/data/ili24/genericValueRanges/multipleContextsExtending.ili
@@ -1,0 +1,46 @@
+INTERLIS 2.4;
+
+MODEL ModelA AT "http://www.interlis.ch/ili2c/tests/" VERSION "1" =
+
+  DOMAIN
+    Coord2 (GENERIC) = COORD NUMERIC, NUMERIC;
+
+    !!@CRS=EPSG:21781
+    Coord2_CHLV03 = COORD
+      460000.000 .. 870000.000,
+       45000.000 .. 310000.000,
+      ROTATION 2 -> 1;
+
+    !!@CRS=EPSG:2056
+    Coord2_CHLV95 = COORD
+      2460000.000 .. 2870000.000,
+      1045000.000 .. 1310000.000,
+      ROTATION 2 -> 1;
+
+  CONTEXT default =
+    Coord2 = Coord2_CHLV03 OR Coord2_CHLV95;
+
+  TOPIC TopicA =
+    CLASS ClassA =
+      attrA : Coord2;
+    END ClassA;
+  END TopicA;
+
+END ModelA.
+
+MODEL ModelB AT "http://www.interlis.ch/ili2c/tests/" VERSION "1"  =
+  IMPORTS UNQUALIFIED ModelA;
+
+  DOMAIN
+    !!@CRS=EPSG:2056
+    Coord2_SmallArea_CHLV95 EXTENDS Coord2_CHLV95 = COORD
+      2460000.000 .. 2500000.000,
+      1200000.000 .. 1310000.000,
+      ROTATION 2 -> 1;
+
+  CONTEXT default =
+    Coord2 = Coord2_SmallArea_CHLV95;
+
+  TOPIC TopicB EXTENDS TopicA =
+  END TopicB;
+END ModelB.

--- a/test/data/ili24/genericValueRanges/multipleContextsExtending.ili
+++ b/test/data/ili24/genericValueRanges/multipleContextsExtending.ili
@@ -21,6 +21,8 @@ MODEL ModelA AT "http://www.interlis.ch/ili2c/tests/" VERSION "1" =
     Coord2 = Coord2_CHLV03 OR Coord2_CHLV95;
 
   TOPIC TopicA =
+    DEFERRED GENERICS Coord2;
+
     CLASS ClassA =
       attrA : Coord2;
     END ClassA;
@@ -29,18 +31,18 @@ MODEL ModelA AT "http://www.interlis.ch/ili2c/tests/" VERSION "1" =
 END ModelA.
 
 MODEL ModelB AT "http://www.interlis.ch/ili2c/tests/" VERSION "1"  =
-  IMPORTS UNQUALIFIED ModelA;
+  IMPORTS ModelA;
 
   DOMAIN
     !!@CRS=EPSG:2056
-    Coord2_SmallArea_CHLV95 EXTENDS Coord2_CHLV95 = COORD
+    Coord2_SmallArea_CHLV95 EXTENDS ModelA.Coord2_CHLV95 = COORD
       2460000.000 .. 2500000.000,
       1200000.000 .. 1310000.000,
       ROTATION 2 -> 1;
 
   CONTEXT default =
-    Coord2 = Coord2_SmallArea_CHLV95;
+    ModelA.Coord2 = Coord2_SmallArea_CHLV95;
 
-  TOPIC TopicB EXTENDS TopicA =
+  TOPIC TopicB EXTENDS ModelA.TopicA =
   END TopicB;
 END ModelB.

--- a/test/data/ili24/genericValueRanges/multipleContextsNotExtending_fail.ili
+++ b/test/data/ili24/genericValueRanges/multipleContextsNotExtending_fail.ili
@@ -21,6 +21,8 @@ MODEL ModelA AT "http://www.interlis.ch/ili2c/tests/" VERSION "1" =
     Coord2 = Coord2_CHLV03 OR Coord2_CHLV95;
 
   TOPIC TopicA =
+    DEFERRED GENERICS Coord2;
+
     CLASS ClassA =
       attrA : Coord2;
     END ClassA;
@@ -29,18 +31,18 @@ MODEL ModelA AT "http://www.interlis.ch/ili2c/tests/" VERSION "1" =
 END ModelA.
 
 MODEL ModelB AT "http://www.interlis.ch/ili2c/tests/" VERSION "1"  =
-  IMPORTS UNQUALIFIED ModelA;
+  IMPORTS ModelA;
 
   DOMAIN
     !!@CRS=EPSG:2056
-    Coord2_SmallArea_CHLV95 EXTENDS Coord2 = COORD
+    Coord2_SmallArea_CHLV95 EXTENDS ModelA.Coord2 = COORD
       2460000.000 .. 2500000.000,
       1200000.000 .. 1310000.000,
       ROTATION 2 -> 1;
 
   CONTEXT default =
-    Coord2 = Coord2_SmallArea_CHLV95; !! Coord2_SmallArea_CHLV95 must extend Coord2_CHLV03 or Coord2_CHLV95
+    ModelA.Coord2 = Coord2_SmallArea_CHLV95; !! Coord2_SmallArea_CHLV95 must extend Coord2_CHLV03 or Coord2_CHLV95
 
-  TOPIC TopicB EXTENDS TopicA =
+  TOPIC TopicB EXTENDS ModelA.TopicA =
   END TopicB;
 END ModelB.

--- a/test/data/ili24/genericValueRanges/multipleContextsNotExtending_fail.ili
+++ b/test/data/ili24/genericValueRanges/multipleContextsNotExtending_fail.ili
@@ -1,0 +1,46 @@
+INTERLIS 2.4;
+
+MODEL ModelA AT "http://www.interlis.ch/ili2c/tests/" VERSION "1" =
+
+  DOMAIN
+    Coord2 (GENERIC) = COORD NUMERIC, NUMERIC;
+
+    !!@CRS=EPSG:21781
+    Coord2_CHLV03 = COORD
+      460000.000 .. 870000.000,
+       45000.000 .. 310000.000,
+      ROTATION 2 -> 1;
+
+    !!@CRS=EPSG:2056
+    Coord2_CHLV95 = COORD
+      2460000.000 .. 2870000.000,
+      1045000.000 .. 1310000.000,
+      ROTATION 2 -> 1;
+
+  CONTEXT default =
+    Coord2 = Coord2_CHLV03 OR Coord2_CHLV95;
+
+  TOPIC TopicA =
+    CLASS ClassA =
+      attrA : Coord2;
+    END ClassA;
+  END TopicA;
+
+END ModelA.
+
+MODEL ModelB AT "http://www.interlis.ch/ili2c/tests/" VERSION "1"  =
+  IMPORTS UNQUALIFIED ModelA;
+
+  DOMAIN
+    !!@CRS=EPSG:2056
+    Coord2_SmallArea_CHLV95 EXTENDS Coord2 = COORD
+      2460000.000 .. 2500000.000,
+      1200000.000 .. 1310000.000,
+      ROTATION 2 -> 1;
+
+  CONTEXT default =
+    Coord2 = Coord2_SmallArea_CHLV95; !! Coord2_SmallArea_CHLV95 must extend Coord2_CHLV03 or Coord2_CHLV95
+
+  TOPIC TopicB EXTENDS TopicA =
+  END TopicB;
+END ModelB.

--- a/test/java/ch/interlis/ili2c/Interlis24/GenericValueRanges24Test.java
+++ b/test/java/ch/interlis/ili2c/Interlis24/GenericValueRanges24Test.java
@@ -47,4 +47,18 @@ public class GenericValueRanges24Test {
         assertEquals(1, errs.getErrs().size());
         assertContainsError("The domain CoordA of context Context1 must be generic.", 1, errs);
     }
+
+    @Test
+    public void multipleContextsExtending() {
+        TransferDescription td = CompilerTestHelper.getTransferDescription(TEST_OUT + "multipleContextsExtending.ili");
+        assertNotNull(td);
+    }
+
+    @Test
+    public void multipleContextsNotExtending() {
+        LogCollector errs = CompilerTestHelper.getCompileErrors(TEST_OUT + "multipleContextsNotExtending_fail.ili");
+
+        assertEquals(1, errs.getErrs().size());
+        assertContainsError("The domain Coord2_SmallArea_CHLV95 must match or extend a domain of the existing context for generic type Coord2.", 1, errs);
+    }
 }


### PR DESCRIPTION
References https://github.com/claeis/ili2c/issues/91