### PR TITLE
ilidoc documentation: add association definition

### DIFF
--- a/doc/ilidoc.rst
+++ b/doc/ilidoc.rst
@@ -90,6 +90,10 @@ Attribut-Definition::
     AttributeDef = { IliDoc } [ [ 'CONTINUOUS' ] 'SUBDIVISION' ]
             Attribute-Name ...
 
+Beziehung-Definition::
+	
+    AssociationDef = { IliDoc } 'ASSOCIATION' Association-Name ...
+
 Rollen-Definition in Assoziationen::
 	
     RoleDef = { IliDoc } Role-Name ...

--- a/doc/ilidoc.rst
+++ b/doc/ilidoc.rst
@@ -100,21 +100,20 @@ Rollen-Definition in Assoziationen::
 
 Wertebereichs-Definition::
 	
-    DomainDef = 'DOMAIN' { { IliDoc } Domain-Name ...
+    DomainDef = 'DOMAIN' { IliDoc } Domain-Name ...
 
 Aufzähltyp-Element::
 
     EnumElement = { IliDoc } EnumElement-Name ...
 
-
 Linienform-Definition::
 	
-   LineFormTypeDef = 'LINE' 'FORM' { { IliDoc } 
+   LineFormTypeDef = 'LINE' 'FORM' { IliDoc } 
       LineFormType-Name ...
 
 Einheiten-Definition::
 	
-   UnitDef = 'UNIT' { { IliDoc } Unit-Name ...
+   UnitDef = 'UNIT' { IliDoc } Unit-Name ...
 
 Definition eines Metaobjekt-Behälters::
 
@@ -131,7 +130,7 @@ Parameter-Definition::
 
 Laufzeitparameter-Definition::
 	
-    RunTimeParameterDef = 'PARAMETER' { { IliDoc } 
+    RunTimeParameterDef = 'PARAMETER' { IliDoc } 
                RunTimeParameter-Name ...
 
 Definition einer Konsistenzbedingung::


### PR DESCRIPTION
Offenbar lassen sich (zumindest im UML-Editor) auch bei Associations ilidoc-Kommentare erfassen/importieren. Dies scheint aber nicht dokumentiert zu sein.